### PR TITLE
cross compiling with os windows

### DIFF
--- a/raylib_ext.c.v
+++ b/raylib_ext.c.v
@@ -7,6 +7,9 @@ module raylib
 
 #flag linux -lraylib -lGL -lm -lpthread -ldl -lrt -lX11
 #flag darwin -lraylib -lm -framework Foundation -framework AppKit -framework OpenGL -framework CoreVideo
+#flag windows -DNOUSER -DNOSHOWWINDOW -DNOGDI
+#flag windows -lraylib@START_LIBS
+#flag windows -lgdi32 -lwinmm
 #include <raylib.h>
 
 @[typedef]


### PR DESCRIPTION
- **Fix the `raygui` and `raymath` submodule compilation with clang-18**
- **Support cross compiling from linux to windows with `-os windows`**
